### PR TITLE
Release version 2.0

### DIFF
--- a/chit-chat-backend/chit-chat-common/src/main/java/chitchat/enums/EnneagramType.java
+++ b/chit-chat-backend/chit-chat-common/src/main/java/chitchat/enums/EnneagramType.java
@@ -6,8 +6,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum EnneagramType {
-    OEN_WING_NINE(0, "1w9"),
-    OEN_WING_TWO(1, "1w2"),
+    ONE_WING_NINE(0, "1w9"),
+    ONE_WING_TWO(1, "1w2"),
     TWO_WING_ONE(2, "2w1"),
     TWO_WING_THREE(3, "2w3"),
     THREE_WING_TWO(4, "3w2"),

--- a/chit-chat-backend/chit-chat-common/src/main/java/chitchat/enums/PersonalityResultType.java
+++ b/chit-chat-backend/chit-chat-common/src/main/java/chitchat/enums/PersonalityResultType.java
@@ -10,8 +10,8 @@ public enum PersonalityResultType {
     CANCEL_ENNEAGRAM_VOTE(-1, "CANCEL_ENNEAGRAM_VOTE", PersonalityTheoryType.ENNEAGRAM),
     CANCEL_MBTI_VOTE(-1, "CANCEL_MBTI_VOTE", PersonalityTheoryType.MBTI),
 
-    OEN_WING_NINE(0, "1w9", PersonalityTheoryType.ENNEAGRAM),
-    OEN_WING_TWO(1, "1w2", PersonalityTheoryType.ENNEAGRAM),
+    ONE_WING_NINE(0, "1w9", PersonalityTheoryType.ENNEAGRAM),
+    ONE_WING_TWO(1, "1w2", PersonalityTheoryType.ENNEAGRAM),
     TWO_WING_ONE(2, "2w1", PersonalityTheoryType.ENNEAGRAM),
     TWO_WING_THREE(3, "2w3", PersonalityTheoryType.ENNEAGRAM),
     THREE_WING_TWO(4, "3w2", PersonalityTheoryType.ENNEAGRAM),

--- a/chit-chat-backend/nginx/nginx.conf
+++ b/chit-chat-backend/nginx/nginx.conf
@@ -52,6 +52,11 @@ http {
             proxy_buffer_size          128k;
             proxy_buffers              4 256k;
             proxy_busy_buffers_size    256k;
+
+#             To maintain connection(websocket), below configurations are needed
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_http_version 1.1;
         }
 
         location / {

--- a/chit-chat-frontend/src/chatting-random/VoteModal.js
+++ b/chit-chat-frontend/src/chatting-random/VoteModal.js
@@ -31,7 +31,7 @@ export default function VoteModal (props) {
     ApiList.voteOtherUserType(voteData);
   }
 
-  const cancelVote = () => {
+  const closeVote = () => {
     console.log(props)
     props.handleCloseModal();
   }
@@ -60,7 +60,7 @@ export default function VoteModal (props) {
             onChange={handleEnneagram}
           />
         </div>
-        <button onClick={cancelVote}>cancel</button>
+        <button onClick={closeVote}>close</button>
       </div>
     </Modal>
    </div>


### PR DESCRIPTION
1. Apply nginx - means server's using only port 80 but not others
2. Change name of button in vote modal ('cancel' -> 'close')
3. Only Google login is available, excluding any other sns(ex. Facebook)
4. Logout is fully working (clearing all cookies & refresh token is deleted in DB)
5. Fix error occurs when voting '1w9', '1w2' personality result type (due to wrong spells)